### PR TITLE
Add missing package for gds version 2.6.0

### DIFF
--- a/.github/workflows/package-opengds.yml
+++ b/.github/workflows/package-opengds.yml
@@ -21,10 +21,10 @@ jobs:
         include:
           - java-version: 11.0.19 # Java 11 is required for Neo4j v4.x
             neo4j-version: 4.4.23
-            gds-version: 2.6.1-23bc767797
+            gds-version: 2.6.0
           - java-version: 17.0.7 # Java 17 is required for Neo4j >= v5.x
             neo4j-version: 5.16.0
-            gds-version: 2.6.1-23bc767797
+            gds-version: 2.6.0
     uses: ./.github/workflows/prepare-opengds.yml
     with:
       java-version: ${{ matrix.java-version }}

--- a/.github/workflows/release-opengds.yml
+++ b/.github/workflows/release-opengds.yml
@@ -12,10 +12,10 @@ jobs:
         include:
           - java-version: 11.0.19
             neo4j-version: 4.4.23
-            gds-version: 2.6.1-23bc767797
+            gds-version: 2.6.0
           - java-version: 17.0.7
             neo4j-version: 5.16.0
-            gds-version: 2.6.1-23bc767797
+            gds-version: 2.6.0
     uses: ./.github/workflows/prepare-opengds.yml
     with:
       java-version: ${{ matrix.java-version }}

--- a/.github/workflows/tag-opengds.yml
+++ b/.github/workflows/tag-opengds.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - gds-version: 2.6.1-23bc767797
+          - gds-version: 2.6.0
     env: 
       CI_COMMIT_AUTHOR: ${{ github.event.repository.name }} git tag bot
     steps:


### PR DESCRIPTION
### Changes

- [Add missing package for gds version 2.6.0](https://github.com/JohT/open-graph-data-science-packaging/pull/22/commits/a734b2e090afbcaa32d55bbc505eb865c57d49c5) since it wasn't created because newer versions already existed.