### PR TITLE
Add missing package for gds version 2.6.1

### DIFF
--- a/.github/workflows/package-opengds.yml
+++ b/.github/workflows/package-opengds.yml
@@ -22,10 +22,10 @@ jobs:
           # Neo4j v4 support dropped with graph-data-science >= v2.7.0
           # - java-version: 11.0.19 # Java 11 is required for Neo4j v4.x
           #   neo4j-version: 4.4.30
-          #   gds-version: 2.7.0-alpha01
+          #   gds-version: 2.6.1
           - java-version: 17.0.7 # Java 17 is required for Neo4j >= v5.x
             neo4j-version: 5.16.0
-            gds-version: 2.7.0-alpha01
+            gds-version: 2.6.1
     uses: ./.github/workflows/prepare-opengds.yml
     with:
       java-version: ${{ matrix.java-version }}

--- a/.github/workflows/release-opengds.yml
+++ b/.github/workflows/release-opengds.yml
@@ -13,10 +13,10 @@ jobs:
           # Neo4j v4 support dropped with graph-data-science >= v2.7.0
           # - java-version: 11.0.19
           #   neo4j-version: 4.4.30
-          #   gds-version: 2.7.0-alpha01
+          #   gds-version: 2.6.1
           - java-version: 17.0.7
             neo4j-version: 5.16.0
-            gds-version: 2.7.0-alpha01
+            gds-version: 2.6.1
     uses: ./.github/workflows/prepare-opengds.yml
     with:
       java-version: ${{ matrix.java-version }}

--- a/.github/workflows/tag-opengds.yml
+++ b/.github/workflows/tag-opengds.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - gds-version: 2.7.0-alpha01
+          - gds-version: 2.6.1
     env: 
       CI_COMMIT_AUTHOR: ${{ github.event.repository.name }} git tag bot
     steps:


### PR DESCRIPTION
### Changes

- [Add missing package for gds version 2.6.1](https://github.com/JohT/open-graph-data-science-packaging/pull/23/commits/4d8c56031d0096bc07875336b784ad304085d81a) since it wasn't created because newer versions already existed.