### PR TITLE
Add package for gds version 2.6.5

### DIFF
--- a/.github/workflows/package-opengds.yml
+++ b/.github/workflows/package-opengds.yml
@@ -25,7 +25,7 @@ jobs:
           #   gds-version: 2.7.0-alpha03
           - java-version: 17.0.7 # Java 17 is required for Neo4j >= v5.x
             neo4j-version: 5.16.0
-            gds-version: 2.7.0-alpha03
+            gds-version: 2.6.5
     uses: ./.github/workflows/prepare-opengds.yml
     with:
       java-version: ${{ matrix.java-version }}

--- a/.github/workflows/release-opengds.yml
+++ b/.github/workflows/release-opengds.yml
@@ -16,7 +16,7 @@ jobs:
           #   gds-version: 2.7.0-alpha03
           - java-version: 17.0.7
             neo4j-version: 5.16.0
-            gds-version: 2.7.0-alpha03
+            gds-version: 2.6.5
     uses: ./.github/workflows/prepare-opengds.yml
     with:
       java-version: ${{ matrix.java-version }}

--- a/.github/workflows/tag-opengds.yml
+++ b/.github/workflows/tag-opengds.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - gds-version: 2.7.0-alpha03
+          - gds-version: 2.6.5
     env: 
       CI_COMMIT_AUTHOR: ${{ github.event.repository.name }} git tag bot
     steps:


### PR DESCRIPTION
### Changes

- [Add package for gds version 2.6.5](https://github.com/JohT/open-graph-data-science-packaging/pull/29/commits/d50a33c8cfca9ac9fc70c3c027e4c60e1cd404f8) since it wasn't created automatically because a newer version already exists.