### PR TITLE
Update neo4j/gds to 2026.03.0

### DIFF
--- a/.github/workflows/package-opengds.yml
+++ b/.github/workflows/package-opengds.yml
@@ -28,8 +28,8 @@ jobs:
           #   neo4j-version = 5.26.5
           #   gds-version = 2.14.0
           - java-version: 21.0.6 # Java 21 is required for Neo4j >= v2025.x
-            neo4j-version: 2026.02.3
-            gds-version: 2.27.1
+            neo4j-version: 2026.03.1
+            gds-version: 2026.03.0
     uses: ./.github/workflows/prepare-opengds.yml
     with:
       java-version: ${{ matrix.java-version }}

--- a/.github/workflows/release-opengds.yml
+++ b/.github/workflows/release-opengds.yml
@@ -19,8 +19,8 @@ jobs:
           #   neo4j-version = 5.26.5
           #   gds-version = 2.14.0
           - java-version: 21.0.6 # Java 21 is required for Neo4j >= v2025.x
-            neo4j-version: 2026.02.3
-            gds-version: 2.27.1
+            neo4j-version: 2026.03.1
+            gds-version: 2026.03.0
     uses: ./.github/workflows/prepare-opengds.yml
     with:
       java-version: ${{ matrix.java-version }}

--- a/.github/workflows/tag-opengds.yml
+++ b/.github/workflows/tag-opengds.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - gds-version: 2.27.1
+          - gds-version: 2026.03.0
             # gds-ref: 71.68.83-v44-310b5f1b7f # Example of how to pass a specific GDS build reference
     env: 
       CI_COMMIT_AUTHOR: ${{ github.event.repository.name }} git tag bot


### PR DESCRIPTION
## 📦 Updates

- [Update neo4j/gds to 2026.03.0](https://github.com/JohT/open-graph-data-science-packaging/pull/109/commits/5b31545d95cb6ef4fa24d664e9b2e37f591b4e93)